### PR TITLE
Release 1.1.0

### DIFF
--- a/src/Testura.Mutation.Console/Properties/AssemblyInfo.cs
+++ b/src/Testura.Mutation.Console/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using Anotar.Log4Net;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
 [assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4Net.config", Watch = true)]
 [assembly: LogMinimalMessage]

--- a/src/Testura.Mutation.Core/Creator/Mutators/ReturnValueMutator.cs
+++ b/src/Testura.Mutation.Core/Creator/Mutators/ReturnValueMutator.cs
@@ -58,7 +58,7 @@ namespace Testura.Mutation.Core.Creator.Mutators
             var objectCreationExpressions = node.DescendantNodes().OfType<ObjectCreationExpressionSyntax>().ToList();
             foreach (var objectCreationExpressionSyntax in objectCreationExpressions)
             {
-                var newNode = node.ReplaceNode(objectCreationExpressionSyntax, SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+                var newNode = node.ReplaceNode(objectCreationExpressionSyntax, SyntaxFactory.DefaultExpression(objectCreationExpressionSyntax.Type));
                 Replacers.Add(new MutationDocumentDetails(node, newNode, GetWhere(node)));
             }
 

--- a/src/Testura.Mutation.VsExtension/Properties/AssemblyInfo.cs
+++ b/src/Testura.Mutation.VsExtension/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/src/Testura.Mutation.VsExtension/Sections/Config/MutationConfigWindowViewModel.cs
+++ b/src/Testura.Mutation.VsExtension/Sections/Config/MutationConfigWindowViewModel.cs
@@ -80,7 +80,7 @@ namespace Testura.Mutation.VsExtension.Sections.Config
                     ProjectGridItems.Add(new ConfigProjectGridItem
                     {
                         IsIgnored = mutationFileConfig?.IgnoredProjects.Any(u => u == projectName) ?? false,
-                        IsTestProject = mutationFileConfig?.TestProjects.Any(u => u == projectName) ?? projectName.EndsWith("Test") || projectName.EndsWith("Tests"),
+                        IsTestProject = mutationFileConfig?.TestProjects.Any(u => u == projectName) ?? projectName.Contains(".Test"),
                         Name = projectName
                     });
                 }
@@ -106,8 +106,8 @@ namespace Testura.Mutation.VsExtension.Sections.Config
 
             var config = new MutationFileConfig
             {
+                SolutionPath = null,
                 IgnoredProjects = ProjectGridItems.Where(s => s.IsIgnored).Select(s => s.Name).ToList(),
-                SolutionPath = _solutionPath,
                 TestProjects = ProjectGridItems.Where(s => s.IsTestProject).Select(s => s.Name).ToList(),
                 TestRunner = TestRunnerTypes[SelectedTestRunnerIndex],
                 CreateBaseline = RunBaseline,
@@ -115,7 +115,7 @@ namespace Testura.Mutation.VsExtension.Sections.Config
                 NumberOfTestRunInstances = NumberOfParallelTestRuns,
             };
 
-            File.WriteAllText(GetConfigPath(), JsonConvert.SerializeObject(config));
+            File.WriteAllText(GetConfigPath(), JsonConvert.SerializeObject(config, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
 
             _environmentService.UserNotificationService.ShowInfoBar<MutationConfigWindow>("Config updated. Note that updates won't affect any currently open mutation windows.");
         }

--- a/src/Testura.Mutation.VsExtension/Services/ConfigService.cs
+++ b/src/Testura.Mutation.VsExtension/Services/ConfigService.cs
@@ -46,8 +46,11 @@ namespace Testura.Mutation.VsExtension.Services
 
                     var solutionPath = _environmentService.Dte.Solution.FullName;
 
-                    return JsonConvert.DeserializeObject<MutationFileConfig>(
+                    var baseConfig = JsonConvert.DeserializeObject<MutationFileConfig>(
                         File.ReadAllText(Path.Combine(Path.GetDirectoryName(solutionPath), TesturaMutationVsExtensionPackage.BaseConfigName)));
+
+                    baseConfig.SolutionPath = solutionPath;
+                    return baseConfig;
                 });
         }
     }

--- a/src/Testura.Mutation.VsExtension/Services/EnvironmentService.cs
+++ b/src/Testura.Mutation.VsExtension/Services/EnvironmentService.cs
@@ -71,5 +71,14 @@ namespace Testura.Mutation.VsExtension.Services
                 ((TextSelection)window.Document.Selection).GotoLine(line, true);
             });
         }
+
+        public string GetSolutionPath()
+        {
+            return JoinableTaskFactory.Run(async () =>
+            {
+                await JoinableTaskFactory.SwitchToMainThreadAsync();
+                return Dte.Solution.FullName;
+            });
+        }
     }
 }

--- a/src/Testura.Mutation.VsExtension/source.extension.vsixmanifest
+++ b/src/Testura.Mutation.VsExtension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" ?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Testura.MutationVsExtension.71e8249a-b76c-4035-af2b-0304cbf33623" Version="1.0" Language="en-US" Publisher="Mille Boström" />
+        <Identity Id="Testura.MutationVsExtension.71e8249a-b76c-4035-af2b-0304cbf33623" Version="1.1.0" Language="en-US" Publisher="Mille Boström" />
         <DisplayName>Testura.Mutation</DisplayName>
         <Description xml:space="preserve">Are you looking for ways to improve the quality and test coverage of your unit tests? Then Testura and mutation testing may be something for you.
 
@@ -10,7 +10,7 @@ Testura is a mutation testing extension for visual studio that verifies the qual
 - Fail it means that your tests found the mutation and you have good coverage.
 - Pass it means that the mutant survived and you do not have sufficient coverage of the specific functionality.</Description>
         <MoreInfo>https://github.com/Testura/Testura.Mutation</MoreInfo>
-        <ReleaseNotes />
+        <ReleaseNotes>https://github.com/Testura/Testura.Mutation/releases</ReleaseNotes>
         <Icon>Resources\bigIcon.png</Icon>
         <PreviewImage>MutationWindow.PNG</PreviewImage>
         <Tags>Mutation tesing unit tests</Tags>

--- a/tests/Testura.Mutation.Tests/Core/Mutation/Mutators/ReturnValueMutatorTests.cs
+++ b/tests/Testura.Mutation.Tests/Core/Mutation/Mutators/ReturnValueMutatorTests.cs
@@ -12,7 +12,7 @@ namespace Testura.Mutation.Tests.Core.Mutation.Mutators
         [TestCase("1", "return 0;", TestName = "GetMutatedDocument_WhenHavingAMethodThatReturn1_ShouldReturn0")]
         [TestCase("0", "return 1;", TestName = "GetMutatedDocument_WhenHavingAMethodThatReturn0_ShouldReturn1")]
         [TestCase("30.2", "return 0;", TestName = "GetMutatedDocument_WhenHavingAMethodThatReturnBiggerNumber_ShouldReturn0")]
-        [TestCase("new Obj()", "return null;", TestName = "GetMutatedDocument_WhenHavingAMethodThatReturnNewObject_ShouldReturnNull")]
+        [TestCase("new Obj()", "return default(Obj);", TestName = "GetMutatedDocument_WhenHavingAMethodThatReturnNewObject_ShouldReturnDefault")]
         [TestCase("null", "throw new System.Exception(\"Mmmmutation\");", TestName = "GetMutatedDocument_WhenHavingAMethodThatReturnNull_ShouldThrowException")]
         [TestCase("\"test\"", "return \"Mutation\";", TestName = "GetMutatedDocument_WhenHavingAMethodThatReturnAString_ShouldNewString")]
         public void Positive(string preMutation, string postMutation)


### PR DESCRIPTION
- Changed so we set SolutionPath to null when saving configuration inside VS extension.  #20 
- Changed so we use current solution path instead of SolutionPath (in config) when creating #20 mutations in VS extension. 
- Changed so we look if project contains ".Test" instead of ending with "Tests" to figure out default test projects in VS extension.
- Changed `return null` mutation to `return default(type)` to prevent many compiler errors.