### PR TITLE
Fixed embedded resources

### DIFF
--- a/src/Testura.Mutation.Console/Properties/AssemblyInfo.cs
+++ b/src/Testura.Mutation.Console/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.7.0.0")]
+[assembly: AssemblyFileVersion("1.7.0.0")]
 [assembly: log4net.Config.XmlConfigurator(ConfigFile = "log4Net.config", Watch = true)]

--- a/src/Testura.Mutation.Core/Execution/Compilation/EmbeddedResourceCreator.cs
+++ b/src/Testura.Mutation.Core/Execution/Compilation/EmbeddedResourceCreator.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Resources;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Testura.Mutation.Core.Execution.Compilation
+{
+    public class EmbeddedResourceCreator
+    {
+        public IEnumerable<ResourceDescription> GetManifestResources(string assemblyName, string projectPath)
+        {
+            var resources = new List<ResourceDescription>();
+            var doc = XDocument.Load(projectPath);
+            var embeddedResources = doc.Descendants().Where(d => d.Name.LocalName.Equals("EmbeddedResource", StringComparison.InvariantCultureIgnoreCase));
+
+            foreach (var embeddedResource in embeddedResources)
+            {
+                var path = GetEmbeddedPath(embeddedResource);
+                if (path == null)
+                {
+                    continue;
+                }
+
+                var resourceFullFilename = Path.Combine(Path.GetDirectoryName(projectPath), path);
+
+                var resourceName =
+                    path.EndsWith(".resx", StringComparison.OrdinalIgnoreCase) ?
+                        path.Remove(path.Length - 5) + ".resources" :
+                        path;
+
+                resources.Add(new ResourceDescription(
+                    $"{assemblyName}.{string.Join(".", resourceName.Split('\\'))}",
+                    () => ProvideResourceData(resourceFullFilename),
+                    true));
+            }
+
+            return resources;
+        }
+
+        private Stream ProvideResourceData(string resourceFullFilename)
+        {
+            // For non-.resx files just create a FileStream object to read the file as binary data
+            if (!resourceFullFilename.EndsWith(".resx", StringComparison.OrdinalIgnoreCase))
+            {
+                return File.OpenRead(resourceFullFilename);
+            }
+
+            var shortLivedBackingStream = new MemoryStream();
+            using (ResourceWriter resourceWriter = new ResourceWriter(shortLivedBackingStream))
+            {
+                resourceWriter.TypeNameConverter = TypeNameConverter;
+                using (var resourceReader = new ResXResourceReader(resourceFullFilename))
+                {
+                    var dictionaryEnumerator = resourceReader.GetEnumerator();
+                    while (dictionaryEnumerator.MoveNext())
+                    {
+                        if (dictionaryEnumerator.Key is string resourceKey)
+                        {
+                            resourceWriter.AddResource(resourceKey, dictionaryEnumerator.Value);
+                        }
+                    }
+                }
+            }
+
+            return new MemoryStream(shortLivedBackingStream.GetBuffer());
+        }
+
+        /// <summary>
+        /// This is needed to fix a "Could not load file or assembly 'System.Drawing, Version=4.0.0.0"
+        /// exception, although I'm not sure why that exception was occurring.
+        /// </summary>
+        private string TypeNameConverter(Type objectType)
+        {
+            return objectType.AssemblyQualifiedName.Replace("4.0.0.0", "2.0.0.0");
+        }
+
+        private string GetEmbeddedPath(XElement embeddedResource)
+        {
+            var paths = embeddedResource.Attribute("Include")?.Value;
+            if (paths != null)
+            {
+                return paths;
+            }
+
+            paths = embeddedResource.Attribute("Update")?.Value;
+            return paths;
+        }
+    }
+}

--- a/src/Testura.Mutation.Core/Testura.Mutation.Core.csproj
+++ b/src/Testura.Mutation.Core/Testura.Mutation.Core.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Enums.cs" />
     <Compile Include="Exceptions\CompilationException.cs" />
     <Compile Include="Exceptions\ProjectSetUpException.cs" />
+    <Compile Include="Execution\Compilation\EmbeddedResourceCreator.cs" />
     <Compile Include="Execution\Compilation\IMutationDocumentCompiler.cs" />
     <Compile Include="Execution\Compilation\IProjectCompiler.cs" />
     <Compile Include="Execution\Report\Html\HtmlOnlyBodyReportCreator.cs" />

--- a/src/Testura.Mutation.VsExtension/Properties/AssemblyInfo.cs
+++ b/src/Testura.Mutation.VsExtension/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.9.1.0")]
-[assembly: AssemblyFileVersion("1.9.1.0")]
+[assembly: AssemblyVersion("1.9.2.0")]
+[assembly: AssemblyFileVersion("1.9.2.0")]

--- a/src/Testura.Mutation.VsExtension/source.extension.vsixmanifest
+++ b/src/Testura.Mutation.VsExtension/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" ?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Testura.MutationVsExtension.71e8249a-b76c-4035-af2b-0304cbf33623" Version="1.9.1" Language="en-US" Publisher="Mille Boström" />
+        <Identity Id="Testura.MutationVsExtension.71e8249a-b76c-4035-af2b-0304cbf33623" Version="1.9.2" Language="en-US" Publisher="Mille Boström" />
         <DisplayName>Testura.Mutation</DisplayName>
         <Description xml:space="preserve">Testura is a mutation testing extension for visual studio that verifies the quality of your unit tests by injecting different mutations in your production code and then checks whether your unit tests catch them.</Description>
         <MoreInfo>https://github.com/Testura/Testura.Mutation</MoreInfo>

--- a/tests/Testura.Mutation.Tests/Core/Execution/Compiler/CompilerTests.cs
+++ b/tests/Testura.Mutation.Tests/Core/Execution/Compiler/CompilerTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Testura.Mutation.Core.Execution.Compilation;
 using Testura.Mutation.Tests.Utils.Creators;
 
 namespace Testura.Mutation.Tests.Core.Execution.Compiler
@@ -18,7 +19,7 @@ namespace Testura.Mutation.Tests.Core.Execution.Compiler
             var project = configCreator.Solution.Projects.Last();
 
 
-            var compiler = new Testura.Mutation.Core.Execution.Compilation.Compiler();
+            var compiler = new Testura.Mutation.Core.Execution.Compilation.Compiler(new EmbeddedResourceCreator());
             var result = await compiler.CompileAsync(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), project);
         }
     }


### PR DESCRIPTION
- Fixed embedded resources for .NET Standard and .NET Core
- Fixed so we read .resx files correctly from embedded resources